### PR TITLE
added api call to spacex data: valuation

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,10 +1,10 @@
 {
     "dev": {
         "contract/valory/erc20/0.1.0": "bafybeibyhuxozkkvsymqz45vxixr3w3bs4vsvxg2nsx5jlyi3f3hhn7ezi",
-        "skill/valory/learning_abci/0.1.0": "bafybeih5m372dqrdfy7w6iah4m5qfgf3j5t7ihsgorzyzhax5srm32wmim",
-        "skill/valory/learning_chained_abci/0.1.0": "bafybeihu6uvvdnfntgluhrbxqus5malsit36xqsyxv46wjqsmuodadarpm",
-        "agent/valory/learning_agent/0.1.0": "bafybeiatizepnj42umexk3p5rnop67cdshbgrflvnysaagm3t4xqo74kem",
-        "service/valory/learning_service/0.1.0": "bafybeig34lg3wztyj7ecsbyb6qj7ryf34gnpr2cuoz3akjvgdsh3pejboq"
+        "skill/valory/learning_abci/0.1.0": "bafybeiaujybsra5cscwxaljrg5jcsh5k4dofrhnzezkpxzxfqw6u7jsy6y",
+        "skill/valory/learning_chained_abci/0.1.0": "bafybeibwdoff2prcngj6aqsj6tk6fm4nimtzg6utw3ros3wawjlk4uengi",
+        "agent/valory/learning_agent/0.1.0": "bafybeibljwsy52x6gy2wdjxairfoahzqtqhx4pxv6z3kl2c3xqbwowzbma",
+        "service/valory/learning_service/0.1.0": "bafybeiemgzvbov2ss2qikescrna2mkmsqt6tql6e6ctfpyzhgy25b66gcu"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",

--- a/packages/valory/agents/learning_agent/aea-config.yaml
+++ b/packages/valory/agents/learning_agent/aea-config.yaml
@@ -32,8 +32,8 @@ protocols:
 skills:
 - valory/abstract_abci:0.1.0:bafybeidz54kvxhbdmpruzguuzzq7bjg4pekjb5amqobkxoy4oqknnobopu
 - valory/abstract_round_abci:0.1.0:bafybeiajjzuh6vf23crp55humonknirvv2f4s3dmdlfzch6tc5ow52pcgm
-- valory/learning_abci:0.1.0:bafybeih5m372dqrdfy7w6iah4m5qfgf3j5t7ihsgorzyzhax5srm32wmim
-- valory/learning_chained_abci:0.1.0:bafybeihu6uvvdnfntgluhrbxqus5malsit36xqsyxv46wjqsmuodadarpm
+- valory/learning_abci:0.1.0:bafybeiaujybsra5cscwxaljrg5jcsh5k4dofrhnzezkpxzxfqw6u7jsy6y
+- valory/learning_chained_abci:0.1.0:bafybeibwdoff2prcngj6aqsj6tk6fm4nimtzg6utw3ros3wawjlk4uengi
 - valory/registration_abci:0.1.0:bafybeiffipsowrqrkhjoexem7ern5ob4fabgif7wa6gtlszcoaop2e3oey
 - valory/reset_pause_abci:0.1.0:bafybeif4lgvbzsmzljesxbphycdv52ka7qnihyjrjpfaseclxadcmm6yiq
 - valory/termination_abci:0.1.0:bafybeiekkpo5qef5zaeagm3si6v45qxcojvtjqe4a5ceccvk4q7k3xi3bi

--- a/packages/valory/services/learning_service/service.yaml
+++ b/packages/valory/services/learning_service/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeid42pdrf6qrohedylj4ijrss236ai6geqgf3he44huowiuf7pl464
 fingerprint_ignore_patterns: []
-agent: valory/learning_agent:0.1.0:bafybeiatizepnj42umexk3p5rnop67cdshbgrflvnysaagm3t4xqo74kem
+agent: valory/learning_agent:0.1.0:bafybeibljwsy52x6gy2wdjxairfoahzqtqhx4pxv6z3kl2c3xqbwowzbma
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/skills/learning_abci/models.py
+++ b/packages/valory/skills/learning_abci/models.py
@@ -59,8 +59,14 @@ class Params(BaseParams):
         # multisend address is used in other skills, so we cannot pop it using _ensure
         self.multisend_address = kwargs.get("multisend_address", "")
 
+        self.spacex_api_url = kwargs.get("spacex_api_url", "https://api.spacexdata.com/v4/company")
+
+
         super().__init__(*args, **kwargs)
 
 
 class CoingeckoSpecs(ApiSpecs):
     """A model that wraps ApiSpecs for Coingecko API."""
+
+class SpacexSpecs(ApiSpecs):
+    """A model that wraps ApiSpecs for SpaceX API."""

--- a/packages/valory/skills/learning_abci/payloads.py
+++ b/packages/valory/skills/learning_abci/payloads.py
@@ -48,3 +48,9 @@ class TxPreparationPayload(BaseTxPayload):
 
     tx_submitter: Optional[str] = None
     tx_hash: Optional[str] = None
+
+@dataclass(frozen=True)
+class SpaceXDataPayload(BaseTxPayload):
+    """Represent a transaction payload for the SpaceXDataRound."""
+
+    company_valuation: Optional[float]

--- a/packages/valory/skills/learning_abci/skill.yaml
+++ b/packages/valory/skills/learning_abci/skill.yaml
@@ -7,13 +7,13 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeiho3lkochqpmes4f235chq26oggmwnol3vjuvhosleoubbjirbwaq
-  behaviours.py: bafybeiaiy6sh7aqo4zzghnejv55vs43vqtpaipj5cpabx32qdjrqleeeie
+  behaviours.py: bafybeiaex6zao3mh5z2xfssb32h5si53hn6x2ukgolufmpbq2n2hi2x2da
   dialogues.py: bafybeifqjbumctlffx2xvpga2kcenezhe47qhksvgmaylyp5ypwqgfar5u
   fsm_specification.yaml: bafybeigbbydxuqephdpatb3fp3sxnvr77bfvvo5hwjimxfpgyl32wupe64
   handlers.py: bafybeigjadr4thz6hfpfx5abezbwnqhbxmachf4efasrn4z2vqhsqgnyvi
-  models.py: bafybeicreffhurci7jzpwvxnlo5z3a2j3vcfgkopg2gtwwxfrncbzk77ra
-  payloads.py: bafybeidc6qqnfvd7qovjatt2i2kbga7pj6epdghlzqxdhzx6b6j6p7ubvm
-  rounds.py: bafybeibcxdou2opzsof4fcnaijfdgzpaaggmucyolhegns3k4zpzvuom2i
+  models.py: bafybeibpz5c7ojnokg54pcjfexmgkpy2pnvrubd6vh6pgazzojfhwxxm2u
+  payloads.py: bafybeihvmlrxelmv43la4arjzjvx5bmb5sparrkc3iuudeb7zcbd3vjlbi
+  rounds.py: bafybeig7kcxatqms6sip7f5wlnlzswt7u23lcoeksgsjyylr67c2qcc7ei
 fingerprint_ignore_patterns: []
 connections: []
 contracts:

--- a/packages/valory/skills/learning_chained_abci/skill.yaml
+++ b/packages/valory/skills/learning_chained_abci/skill.yaml
@@ -22,7 +22,7 @@ skills:
 - valory/registration_abci:0.1.0:bafybeiffipsowrqrkhjoexem7ern5ob4fabgif7wa6gtlszcoaop2e3oey
 - valory/reset_pause_abci:0.1.0:bafybeif4lgvbzsmzljesxbphycdv52ka7qnihyjrjpfaseclxadcmm6yiq
 - valory/termination_abci:0.1.0:bafybeiekkpo5qef5zaeagm3si6v45qxcojvtjqe4a5ceccvk4q7k3xi3bi
-- valory/learning_abci:0.1.0:bafybeih5m372dqrdfy7w6iah4m5qfgf3j5t7ihsgorzyzhax5srm32wmim
+- valory/learning_abci:0.1.0:bafybeiaujybsra5cscwxaljrg5jcsh5k4dofrhnzezkpxzxfqw6u7jsy6y
 - valory/transaction_settlement_abci:0.1.0:bafybeielv6eivt2z6nforq43xewl2vmpfwpdu2s2vfogobziljnwsclmlm
 behaviours:
   main:


### PR DESCRIPTION
Here's a clear PR description highlighting the changes:

# Pull Request: Add SpaceX Company Data Round

## Changes
- Added a new round `SpaceXDataRound` between DataPull and DecisionMaking rounds
- Created new payload `SpaceXDataPayload` to handle company valuation data
- Implemented `SpaceXDataBehaviour` to fetch SpaceX company data
- Enhanced logging with formatted currency display showing both full value and billions notation

## Technical Details
- State machine flow updated: `DataPullRound -> SpaceXDataRound -> DecisionMakingRound`
- API endpoint: `https://api.spacexdata.com/v4/company` 
- Added currency formatting for better readability
  - Full format: `$74,000,000,000.00 USD`
  
## Testing
- Verified correct state transitions through rounds
- Confirmed API data retrieval
- Tested currency formatting for readability

## Related Files Modified
- rounds.py
- behaviours.py
- payloads.py
- models.py

Would you like me to adjust the PR description to include any other details?