### PR TITLE
put and fetch on ipfs

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,10 +1,10 @@
 {
     "dev": {
         "contract/valory/erc20/0.1.0": "bafybeibyhuxozkkvsymqz45vxixr3w3bs4vsvxg2nsx5jlyi3f3hhn7ezi",
-        "skill/valory/learning_abci/0.1.0": "bafybeiaujybsra5cscwxaljrg5jcsh5k4dofrhnzezkpxzxfqw6u7jsy6y",
-        "skill/valory/learning_chained_abci/0.1.0": "bafybeibwdoff2prcngj6aqsj6tk6fm4nimtzg6utw3ros3wawjlk4uengi",
-        "agent/valory/learning_agent/0.1.0": "bafybeibljwsy52x6gy2wdjxairfoahzqtqhx4pxv6z3kl2c3xqbwowzbma",
-        "service/valory/learning_service/0.1.0": "bafybeiemgzvbov2ss2qikescrna2mkmsqt6tql6e6ctfpyzhgy25b66gcu"
+        "skill/valory/learning_abci/0.1.0": "bafybeihffs5c7sx7hknmm2rullsehbuw6cy7nahcayou32xcim5nsknrqq",
+        "skill/valory/learning_chained_abci/0.1.0": "bafybeih7cg2mlckjgl5xeu2233br6h3wxkxgj7sc5etvdwd6vx2gkp5zhy",
+        "agent/valory/learning_agent/0.1.0": "bafybeiepcowslqetivtdsg25rqcjig5of5uovgfpilvvxhaj6ofbwnllsi",
+        "service/valory/learning_service/0.1.0": "bafybeifjaw5t5fkpp6euykeu3m2xh2oahxkus7shnpoo2cnnrujep3yuwm"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",

--- a/packages/valory/agents/learning_agent/aea-config.yaml
+++ b/packages/valory/agents/learning_agent/aea-config.yaml
@@ -32,8 +32,8 @@ protocols:
 skills:
 - valory/abstract_abci:0.1.0:bafybeidz54kvxhbdmpruzguuzzq7bjg4pekjb5amqobkxoy4oqknnobopu
 - valory/abstract_round_abci:0.1.0:bafybeiajjzuh6vf23crp55humonknirvv2f4s3dmdlfzch6tc5ow52pcgm
-- valory/learning_abci:0.1.0:bafybeiaujybsra5cscwxaljrg5jcsh5k4dofrhnzezkpxzxfqw6u7jsy6y
-- valory/learning_chained_abci:0.1.0:bafybeibwdoff2prcngj6aqsj6tk6fm4nimtzg6utw3ros3wawjlk4uengi
+- valory/learning_abci:0.1.0:bafybeihffs5c7sx7hknmm2rullsehbuw6cy7nahcayou32xcim5nsknrqq
+- valory/learning_chained_abci:0.1.0:bafybeih7cg2mlckjgl5xeu2233br6h3wxkxgj7sc5etvdwd6vx2gkp5zhy
 - valory/registration_abci:0.1.0:bafybeiffipsowrqrkhjoexem7ern5ob4fabgif7wa6gtlszcoaop2e3oey
 - valory/reset_pause_abci:0.1.0:bafybeif4lgvbzsmzljesxbphycdv52ka7qnihyjrjpfaseclxadcmm6yiq
 - valory/termination_abci:0.1.0:bafybeiekkpo5qef5zaeagm3si6v45qxcojvtjqe4a5ceccvk4q7k3xi3bi

--- a/packages/valory/services/learning_service/service.yaml
+++ b/packages/valory/services/learning_service/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeid42pdrf6qrohedylj4ijrss236ai6geqgf3he44huowiuf7pl464
 fingerprint_ignore_patterns: []
-agent: valory/learning_agent:0.1.0:bafybeibljwsy52x6gy2wdjxairfoahzqtqhx4pxv6z3kl2c3xqbwowzbma
+agent: valory/learning_agent:0.1.0:bafybeiepcowslqetivtdsg25rqcjig5of5uovgfpilvvxhaj6ofbwnllsi
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/skills/learning_abci/payloads.py
+++ b/packages/valory/skills/learning_abci/payloads.py
@@ -54,3 +54,4 @@ class SpaceXDataPayload(BaseTxPayload):
     """Represent a transaction payload for the SpaceXDataRound."""
 
     company_valuation: Optional[float]
+    company_valuation_ipfs_hash: Optional[str]

--- a/packages/valory/skills/learning_abci/rounds.py
+++ b/packages/valory/skills/learning_abci/rounds.py
@@ -108,6 +108,11 @@ class SynchronizedData(BaseSynchronizedData):
     def company_valuation(self) -> Optional[float]:
         """Get the company valuation."""
         return self.db.get("company_valuation", None)
+
+    @property
+    def company_valuation_ipfs_hash(self) -> Optional[str]:
+        """Get the company valuation ipfs hash."""
+        return self.db.get("company_valuation_ipfs_hash", None)
     
     @property
     def participant_to_spacex_round(self) -> DeserializedCollection:
@@ -148,6 +153,7 @@ class SpaceXDataRound(CollectSameUntilThresholdRound):
     collection_key = get_name(SynchronizedData.participant_to_spacex_round)
     selection_key = (
         get_name(SynchronizedData.company_valuation),
+        get_name(SynchronizedData.company_valuation_ipfs_hash),
     )    
     
 class DecisionMakingRound(CollectSameUntilThresholdRound):

--- a/packages/valory/skills/learning_abci/skill.yaml
+++ b/packages/valory/skills/learning_abci/skill.yaml
@@ -7,13 +7,13 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeiho3lkochqpmes4f235chq26oggmwnol3vjuvhosleoubbjirbwaq
-  behaviours.py: bafybeiaex6zao3mh5z2xfssb32h5si53hn6x2ukgolufmpbq2n2hi2x2da
+  behaviours.py: bafybeifawrsu4iopyt3fadabvywtackxyy7oxbquee7uhghe7fdpwhkcjy
   dialogues.py: bafybeifqjbumctlffx2xvpga2kcenezhe47qhksvgmaylyp5ypwqgfar5u
   fsm_specification.yaml: bafybeigbbydxuqephdpatb3fp3sxnvr77bfvvo5hwjimxfpgyl32wupe64
   handlers.py: bafybeigjadr4thz6hfpfx5abezbwnqhbxmachf4efasrn4z2vqhsqgnyvi
   models.py: bafybeibpz5c7ojnokg54pcjfexmgkpy2pnvrubd6vh6pgazzojfhwxxm2u
-  payloads.py: bafybeihvmlrxelmv43la4arjzjvx5bmb5sparrkc3iuudeb7zcbd3vjlbi
-  rounds.py: bafybeig7kcxatqms6sip7f5wlnlzswt7u23lcoeksgsjyylr67c2qcc7ei
+  payloads.py: bafybeig7s7lbj2aqjq7dtjnl3hbtnqxzbrsp4jvno2ymyyhhihcb6aiymq
+  rounds.py: bafybeia6lajcur32orvoceea5z5rws4preedr3jlbuxzrdvce3xv7aljhi
 fingerprint_ignore_patterns: []
 connections: []
 contracts:

--- a/packages/valory/skills/learning_chained_abci/skill.yaml
+++ b/packages/valory/skills/learning_chained_abci/skill.yaml
@@ -22,7 +22,7 @@ skills:
 - valory/registration_abci:0.1.0:bafybeiffipsowrqrkhjoexem7ern5ob4fabgif7wa6gtlszcoaop2e3oey
 - valory/reset_pause_abci:0.1.0:bafybeif4lgvbzsmzljesxbphycdv52ka7qnihyjrjpfaseclxadcmm6yiq
 - valory/termination_abci:0.1.0:bafybeiekkpo5qef5zaeagm3si6v45qxcojvtjqe4a5ceccvk4q7k3xi3bi
-- valory/learning_abci:0.1.0:bafybeiaujybsra5cscwxaljrg5jcsh5k4dofrhnzezkpxzxfqw6u7jsy6y
+- valory/learning_abci:0.1.0:bafybeihffs5c7sx7hknmm2rullsehbuw6cy7nahcayou32xcim5nsknrqq
 - valory/transaction_settlement_abci:0.1.0:bafybeielv6eivt2z6nforq43xewl2vmpfwpdu2s2vfogobziljnwsclmlm
 behaviours:
   main:


### PR DESCRIPTION
# Pull Request: Add IPFS Storage for SpaceX Valuation Data

## Changes
- Enhanced SpaceXDataRound to store and retrieve company valuation from IPFS
- Added data verification by reading back stored IPFS data
- Improved logging to show both stored and retrieved data states

## Technical Details
- Added IPFS storage functionality in `SpaceXDataBehaviour`:
  ```python
  # Store: {"company_valuation": 74000000000}
  ipfs_hash = yield from self.send_to_ipfs(
      filename=self.metadata_filepath,
      obj=stored_data,
      filetype=SupportedFiletype.JSON
  )
  ```
- Implemented immediate IPFS data verification:
  - Store valuation data
  - Retrieve using generated IPFS hash
  - Verify retrieved data matches stored data
- Added logging at each step:
  - When data is stored to IPFS
  - When data is retrieved from IPFS
  - Data verification results

## Data Flow
1. Fetch SpaceX valuation from API
2. Format and store in IPFS
3. Retrieve from IPFS to verify storage
4. Compare stored vs retrieved data
5. Log all steps for transparency

## Testing
- Verified IPFS storage successful
- Confirmed data retrieval matches stored data
- Validated logging output for all operations

## Related Files Modified
- behaviours.py (SpaceXDataBehaviour class)
