### PR TITLE
added a round NativeTransferRound for native transfer along with NativeTransferBehaviour

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,10 +1,10 @@
 {
     "dev": {
         "contract/valory/erc20/0.1.0": "bafybeibyhuxozkkvsymqz45vxixr3w3bs4vsvxg2nsx5jlyi3f3hhn7ezi",
-        "skill/valory/learning_abci/0.1.0": "bafybeihffs5c7sx7hknmm2rullsehbuw6cy7nahcayou32xcim5nsknrqq",
-        "skill/valory/learning_chained_abci/0.1.0": "bafybeih7cg2mlckjgl5xeu2233br6h3wxkxgj7sc5etvdwd6vx2gkp5zhy",
-        "agent/valory/learning_agent/0.1.0": "bafybeiepcowslqetivtdsg25rqcjig5of5uovgfpilvvxhaj6ofbwnllsi",
-        "service/valory/learning_service/0.1.0": "bafybeifjaw5t5fkpp6euykeu3m2xh2oahxkus7shnpoo2cnnrujep3yuwm"
+        "skill/valory/learning_abci/0.1.0": "bafybeiec7b3trh5q2xyvanqm5kttqbysdnp7rwac4nx4yvifimz7rw4qzy",
+        "skill/valory/learning_chained_abci/0.1.0": "bafybeieobq5tgipb5we5bfkblmefspngocjrxm455iystcw5562vaujduu",
+        "agent/valory/learning_agent/0.1.0": "bafybeic3rit67tvl5zzvwbxjmthkr5uykx46y4zxphjarfnya4f6vof7sy",
+        "service/valory/learning_service/0.1.0": "bafybeihjlwzjov3duna2wwfet274vqsqqj6rz4ck5in2qzcezsd5zjowri"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",

--- a/packages/valory/agents/learning_agent/aea-config.yaml
+++ b/packages/valory/agents/learning_agent/aea-config.yaml
@@ -32,8 +32,8 @@ protocols:
 skills:
 - valory/abstract_abci:0.1.0:bafybeidz54kvxhbdmpruzguuzzq7bjg4pekjb5amqobkxoy4oqknnobopu
 - valory/abstract_round_abci:0.1.0:bafybeiajjzuh6vf23crp55humonknirvv2f4s3dmdlfzch6tc5ow52pcgm
-- valory/learning_abci:0.1.0:bafybeihffs5c7sx7hknmm2rullsehbuw6cy7nahcayou32xcim5nsknrqq
-- valory/learning_chained_abci:0.1.0:bafybeih7cg2mlckjgl5xeu2233br6h3wxkxgj7sc5etvdwd6vx2gkp5zhy
+- valory/learning_abci:0.1.0:bafybeiec7b3trh5q2xyvanqm5kttqbysdnp7rwac4nx4yvifimz7rw4qzy
+- valory/learning_chained_abci:0.1.0:bafybeieobq5tgipb5we5bfkblmefspngocjrxm455iystcw5562vaujduu
 - valory/registration_abci:0.1.0:bafybeiffipsowrqrkhjoexem7ern5ob4fabgif7wa6gtlszcoaop2e3oey
 - valory/reset_pause_abci:0.1.0:bafybeif4lgvbzsmzljesxbphycdv52ka7qnihyjrjpfaseclxadcmm6yiq
 - valory/termination_abci:0.1.0:bafybeiekkpo5qef5zaeagm3si6v45qxcojvtjqe4a5ceccvk4q7k3xi3bi

--- a/packages/valory/services/learning_service/service.yaml
+++ b/packages/valory/services/learning_service/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeid42pdrf6qrohedylj4ijrss236ai6geqgf3he44huowiuf7pl464
 fingerprint_ignore_patterns: []
-agent: valory/learning_agent:0.1.0:bafybeiepcowslqetivtdsg25rqcjig5of5uovgfpilvvxhaj6ofbwnllsi
+agent: valory/learning_agent:0.1.0:bafybeic3rit67tvl5zzvwbxjmthkr5uykx46y4zxphjarfnya4f6vof7sy
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/skills/learning_abci/behaviours.py
+++ b/packages/valory/skills/learning_abci/behaviours.py
@@ -23,7 +23,7 @@ import json
 from abc import ABC
 from pathlib import Path
 from tempfile import mkdtemp
-from typing import Dict, Generator, Optional, Set, Type, cast
+from typing import Dict, Generator, Optional, Set, Tuple, Type, cast
 
 from packages.valory.contracts.erc20.contract import ERC20
 from packages.valory.contracts.gnosis_safe.contract import (
@@ -50,6 +50,7 @@ from packages.valory.skills.learning_abci.models import (
 from packages.valory.skills.learning_abci.payloads import (
     DataPullPayload,
     DecisionMakingPayload,
+    NativeTransferPayload,
     SpaceXDataPayload,
     TxPreparationPayload,
 )
@@ -58,6 +59,7 @@ from packages.valory.skills.learning_abci.rounds import (
     DecisionMakingRound,
     Event,
     LearningAbciApp,
+    NativeTransferRound,
     SpaceXDataRound,
     SynchronizedData,
     TxPreparationRound,
@@ -363,6 +365,115 @@ class SpaceXDataBehaviour(LearningBaseBehaviour):
         data = json.loads(response.body)
         self.context.logger.info(f"Get SpaceX data API call successfull")
         return data
+
+class NativeTransferBehaviour(LearningBaseBehaviour):
+    """NativeTransferBehaviour"""
+
+    matching_round: Type[AbstractRound] = NativeTransferRound
+
+    def async_act(self) -> Generator:
+        """Do the act, supporting asynchronous execution."""
+
+        with self.context.benchmark_tool.measure(self.behaviour_id).local():
+            sender = self.context.agent_address
+
+            # Get the transaction hash
+            tx_hash = yield from self.get_tx_hash()
+
+            payload = NativeTransferPayload(
+                sender=sender,
+                tx_submitter=self.auto_behaviour_id(),
+                tx_hash=tx_hash,
+            )
+
+        with self.context.benchmark_tool.measure(self.behaviour_id).consensus():
+            yield from self.send_a2a_transaction(payload)
+            yield from self.wait_until_round_end()
+
+        self.set_done()
+
+    def get_tx_hash(self) -> Generator[None, None, Optional[str]]:
+        """Get the transaction hash"""
+
+        # Get native transfer safe tx hash
+        safe_tx_hash = yield from self.get_native_transfer_safe_tx_hash()
+        self.context.logger.info(f"Native transfer hash is {safe_tx_hash}")
+
+        return safe_tx_hash
+
+    def get_native_transfer_safe_tx_hash(self) -> Generator[None, None, Optional[str]]:
+        """Prepare a native safe transaction"""
+
+        # Transaction data
+        data = {VALUE_KEY: 1, TO_ADDRESS_KEY: self.params.transfer_target_address}
+        self.context.logger.info(f"Native transfer data is {data}")
+
+        # Prepare safe transaction
+        safe_tx_hash = yield from self._build_safe_tx_hash(**data)
+        return safe_tx_hash
+
+    def _build_safe_tx_hash(
+        self,
+        to_address: str,
+        value: int = ZERO_VALUE,
+        data: bytes = EMPTY_CALL_DATA,
+        operation: int = SafeOperation.CALL.value,
+    ) -> Generator[None, None, Optional[str]]:
+        """Prepares and returns the safe tx hash for a native tx."""
+
+        self.context.logger.info(
+            f"Preparing Safe transaction [{self.synchronized_data.safe_contract_address}]"
+        )
+
+        # Prepare the safe transaction
+        response_msg = yield from self.get_contract_api_response(
+            performative=ContractApiMessage.Performative.GET_STATE,  # type: ignore
+            contract_address=self.synchronized_data.safe_contract_address,
+            contract_id=str(GnosisSafeContract.contract_id),
+            contract_callable="get_raw_safe_transaction_hash",
+            to_address=to_address,
+            value=value,
+            data=data,
+            safe_tx_gas=SAFE_GAS,
+            chain_id=GNOSIS_CHAIN_ID,
+            operation=operation,
+        )
+
+        # Check for errors
+        if response_msg.performative != ContractApiMessage.Performative.STATE:
+            self.context.logger.error(
+                "Couldn't get safe tx hash. Expected response performative "
+                f"{ContractApiMessage.Performative.STATE.value!r}, "  # type: ignore
+                f"received {response_msg.performative.value!r}: {response_msg}."
+            )
+            return None
+
+        # Extract the hash and check it has the correct length
+        tx_hash: Optional[str] = response_msg.state.body.get("tx_hash", None)
+
+        if tx_hash is None or len(tx_hash) != TX_HASH_LENGTH:
+            self.context.logger.error(
+                "Something went wrong while trying to get the safe transaction hash. "
+                f"Invalid hash {tx_hash!r} was returned."
+            )
+            return None
+
+        # Transaction to hex
+        tx_hash = tx_hash[2:]  # strip the 0x
+
+        safe_tx_hash = hash_payload_to_hex(
+            safe_tx_hash=tx_hash,
+            ether_value=value,
+            safe_tx_gas=SAFE_GAS,
+            to_address=to_address,
+            data=data,
+            operation=operation,
+        )
+
+        self.context.logger.info(f"Safe transaction hash is {safe_tx_hash}")
+
+        return safe_tx_hash
+
 class DecisionMakingBehaviour(
     LearningBaseBehaviour
 ):  # pylint: disable=too-many-ancestors
@@ -743,6 +854,7 @@ class LearningRoundBehaviour(AbstractRoundBehaviour):
     behaviours: Set[Type[BaseBehaviour]] = [  # type: ignore
         DataPullBehaviour,
         SpaceXDataBehaviour,
+        NativeTransferBehaviour,
         DecisionMakingBehaviour,
         TxPreparationBehaviour,
     ]

--- a/packages/valory/skills/learning_abci/payloads.py
+++ b/packages/valory/skills/learning_abci/payloads.py
@@ -55,3 +55,10 @@ class SpaceXDataPayload(BaseTxPayload):
 
     company_valuation: Optional[float]
     company_valuation_ipfs_hash: Optional[str]
+
+@dataclass(frozen=True)
+class NativeTransferPayload(BaseTxPayload):
+    """Represent a transaction payload for the NativeTransferRound."""
+
+    tx_submitter: Optional[str]
+    tx_hash: Optional[str]

--- a/packages/valory/skills/learning_abci/skill.yaml
+++ b/packages/valory/skills/learning_abci/skill.yaml
@@ -7,13 +7,13 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeiho3lkochqpmes4f235chq26oggmwnol3vjuvhosleoubbjirbwaq
-  behaviours.py: bafybeifawrsu4iopyt3fadabvywtackxyy7oxbquee7uhghe7fdpwhkcjy
+  behaviours.py: bafybeid2styrysmcvpbeht66az7gnsdfpa7wm436fq52bdduguk7pwmzxm
   dialogues.py: bafybeifqjbumctlffx2xvpga2kcenezhe47qhksvgmaylyp5ypwqgfar5u
   fsm_specification.yaml: bafybeigbbydxuqephdpatb3fp3sxnvr77bfvvo5hwjimxfpgyl32wupe64
   handlers.py: bafybeigjadr4thz6hfpfx5abezbwnqhbxmachf4efasrn4z2vqhsqgnyvi
   models.py: bafybeibpz5c7ojnokg54pcjfexmgkpy2pnvrubd6vh6pgazzojfhwxxm2u
-  payloads.py: bafybeig7s7lbj2aqjq7dtjnl3hbtnqxzbrsp4jvno2ymyyhhihcb6aiymq
-  rounds.py: bafybeia6lajcur32orvoceea5z5rws4preedr3jlbuxzrdvce3xv7aljhi
+  payloads.py: bafybeiegiapnm5zkchgb5mloggk446q375pogjrj6diph4oxzpxw3uboqi
+  rounds.py: bafybeihm47ykgf5si6kgzcyryvme5ph5jm27g7nydl2s3lavtaoyhumcf4
 fingerprint_ignore_patterns: []
 connections: []
 contracts:

--- a/packages/valory/skills/learning_chained_abci/skill.yaml
+++ b/packages/valory/skills/learning_chained_abci/skill.yaml
@@ -22,7 +22,7 @@ skills:
 - valory/registration_abci:0.1.0:bafybeiffipsowrqrkhjoexem7ern5ob4fabgif7wa6gtlszcoaop2e3oey
 - valory/reset_pause_abci:0.1.0:bafybeif4lgvbzsmzljesxbphycdv52ka7qnihyjrjpfaseclxadcmm6yiq
 - valory/termination_abci:0.1.0:bafybeiekkpo5qef5zaeagm3si6v45qxcojvtjqe4a5ceccvk4q7k3xi3bi
-- valory/learning_abci:0.1.0:bafybeihffs5c7sx7hknmm2rullsehbuw6cy7nahcayou32xcim5nsknrqq
+- valory/learning_abci:0.1.0:bafybeiec7b3trh5q2xyvanqm5kttqbysdnp7rwac4nx4yvifimz7rw4qzy
 - valory/transaction_settlement_abci:0.1.0:bafybeielv6eivt2z6nforq43xewl2vmpfwpdu2s2vfogobziljnwsclmlm
 behaviours:
   main:


### PR DESCRIPTION
Here's a PR description for the changes we made to the Learning service:

# Native Transfer Round Support

## Summary
Added dedicated behaviour and round for handling native token transfers within the LearningAbciApp. This enhancement separates native transfer functionality from ERC20/contract interactions for clearer code organization and better separation of concerns.

## Changes 
- Added `NativeTransferPayload` for consensus data handling
- Created `NativeTransferRound` following existing round patterns
- Implemented `NativeTransferBehaviour` mirroring TxPreparationBehaviour structure
- Updated FSM and transition functions to include new round support
- Updated SynchronizedData with native transfer related properties

## Implementation Details
### New Payload
```python
@dataclass(frozen=True)
class NativeTransferPayload(BaseTxPayload):
    """Represent a transaction payload for the NativeTransferRound."""
    tx_submitter: Optional[str]
    tx_hash: Optional[str]
```

### Round Flow
Added native transfer handling in ABCIApp transitions:
```python
TxPreparationRound: {
    Event.DONE: NativeTransferRound,
    ...
},
NativeTransferRound: {
    Event.DONE: FinishedTxPreparationRound,
    ...
}
```

### Key Features
- Reuses safe transaction patterns from base classes
- Maintains consistent logging throughout transaction preparation
- Uses similar consensus mechanism as existing transaction rounds
- Simple 1 wei transfers for testing and demonstration

## Testing
- Test native transfer round transitions
- Verify safe transaction hash generation
- Ensure consensus is reached on transaction data
- Validate proper logging and error handling

