### PR TITLE
Feat/read smart contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ packages/valory/skills/*
 !packages/valory/skills/learning_abci
 !packages/valory/skills/learning_chained_abci
 !packages/valory/contracts/erc20
+!packages/valory/contracts/token_reader
 
 leak_report
 /Pipfile.lock

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,10 +1,11 @@
 {
     "dev": {
         "contract/valory/erc20/0.1.0": "bafybeibyhuxozkkvsymqz45vxixr3w3bs4vsvxg2nsx5jlyi3f3hhn7ezi",
-        "skill/valory/learning_abci/0.1.0": "bafybeiec7b3trh5q2xyvanqm5kttqbysdnp7rwac4nx4yvifimz7rw4qzy",
-        "skill/valory/learning_chained_abci/0.1.0": "bafybeieobq5tgipb5we5bfkblmefspngocjrxm455iystcw5562vaujduu",
-        "agent/valory/learning_agent/0.1.0": "bafybeic3rit67tvl5zzvwbxjmthkr5uykx46y4zxphjarfnya4f6vof7sy",
-        "service/valory/learning_service/0.1.0": "bafybeihjlwzjov3duna2wwfet274vqsqqj6rz4ck5in2qzcezsd5zjowri"
+        "contract/valory/token_reader/0.1.0": "bafybeifmylu4yddfy2zyrb34cw5fcxrkj7x73zbvlxhrdc7cqxnt5jypti",
+        "skill/valory/learning_abci/0.1.0": "bafybeia3hfwbnfiaovv7ck4hodssd5xvsynrg5gz7h6o2kwlggbh6ct6bm",
+        "skill/valory/learning_chained_abci/0.1.0": "bafybeicvpppvm5suyf64hwbswucjeislmqmg4ufr6kuqgs55d6rwsfxmwq",
+        "agent/valory/learning_agent/0.1.0": "bafybeidjdpdkwrr2wpgoqqmp6ycn37ji2wobquvhdnc2uexksr2glknloy",
+        "service/valory/learning_service/0.1.0": "bafybeidsxh6r3cxxc6itz6lwrxtpfzwkbvriinbr3vqgqdetr5ue2jwe4u"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",

--- a/packages/valory/agents/learning_agent/aea-config.yaml
+++ b/packages/valory/agents/learning_agent/aea-config.yaml
@@ -32,8 +32,8 @@ protocols:
 skills:
 - valory/abstract_abci:0.1.0:bafybeidz54kvxhbdmpruzguuzzq7bjg4pekjb5amqobkxoy4oqknnobopu
 - valory/abstract_round_abci:0.1.0:bafybeiajjzuh6vf23crp55humonknirvv2f4s3dmdlfzch6tc5ow52pcgm
-- valory/learning_abci:0.1.0:bafybeiec7b3trh5q2xyvanqm5kttqbysdnp7rwac4nx4yvifimz7rw4qzy
-- valory/learning_chained_abci:0.1.0:bafybeieobq5tgipb5we5bfkblmefspngocjrxm455iystcw5562vaujduu
+- valory/learning_abci:0.1.0:bafybeia3hfwbnfiaovv7ck4hodssd5xvsynrg5gz7h6o2kwlggbh6ct6bm
+- valory/learning_chained_abci:0.1.0:bafybeicvpppvm5suyf64hwbswucjeislmqmg4ufr6kuqgs55d6rwsfxmwq
 - valory/registration_abci:0.1.0:bafybeiffipsowrqrkhjoexem7ern5ob4fabgif7wa6gtlszcoaop2e3oey
 - valory/reset_pause_abci:0.1.0:bafybeif4lgvbzsmzljesxbphycdv52ka7qnihyjrjpfaseclxadcmm6yiq
 - valory/termination_abci:0.1.0:bafybeiekkpo5qef5zaeagm3si6v45qxcojvtjqe4a5ceccvk4q7k3xi3bi

--- a/packages/valory/contracts/token_reader/README.md
+++ b/packages/valory/contracts/token_reader/README.md
@@ -1,0 +1,1 @@
+# ERC20 token contract

--- a/packages/valory/contracts/token_reader/__init__.py
+++ b/packages/valory/contracts/token_reader/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2023-2024 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This module contains the support resources for an ERC20 token."""

--- a/packages/valory/contracts/token_reader/build/token_reader.json
+++ b/packages/valory/contracts/token_reader/build/token_reader.json
@@ -1,0 +1,288 @@
+{
+  "_format": "",
+  "contractName": "",
+  "sourceName": "",
+  "abi": [
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "name",
+      "outputs": [
+        {
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "guy",
+          "type": "address"
+        },
+        {
+          "name": "wad",
+          "type": "uint256"
+        }
+      ],
+      "name": "approve",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "totalSupply",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "src",
+          "type": "address"
+        },
+        {
+          "name": "dst",
+          "type": "address"
+        },
+        {
+          "name": "wad",
+          "type": "uint256"
+        }
+      ],
+      "name": "transferFrom",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "wad",
+          "type": "uint256"
+        }
+      ],
+      "name": "withdraw",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "decimals",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "balanceOf",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "symbol",
+      "outputs": [
+        {
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "dst",
+          "type": "address"
+        },
+        {
+          "name": "wad",
+          "type": "uint256"
+        }
+      ],
+      "name": "transfer",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [],
+      "name": "deposit",
+      "outputs": [],
+      "payable": true,
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "",
+          "type": "address"
+        },
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "allowance",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "payable": true,
+      "stateMutability": "payable",
+      "type": "fallback"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "src",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "name": "guy",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "wad",
+          "type": "uint256"
+        }
+      ],
+      "name": "Approval",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "src",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "name": "dst",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "wad",
+          "type": "uint256"
+        }
+      ],
+      "name": "Transfer",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "dst",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "wad",
+          "type": "uint256"
+        }
+      ],
+      "name": "Deposit",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "src",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "wad",
+          "type": "uint256"
+        }
+      ],
+      "name": "Withdrawal",
+      "type": "event"
+    }
+  ],
+  "bytecode": "",
+  "deployedBytecode": "",
+  "linkReferences": {},
+  "deployedLinkReferences": {}
+}

--- a/packages/valory/contracts/token_reader/contract.py
+++ b/packages/valory/contracts/token_reader/contract.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2023-2024 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This module contains the class to connect to an ERC20 token contract."""
+
+from typing import Dict, List
+
+from aea.common import JSONLike
+from aea.configurations.base import PublicId
+from aea.contracts.base import Contract
+from aea.crypto.base import LedgerApi
+from aea_ledger_ethereum import EthereumApi
+from eth_typing import BlockIdentifier
+
+
+PUBLIC_ID = PublicId.from_str("valory/token_reader:0.1.0")
+
+class TokenReaderContract(Contract):
+    """A simple contract to read token balances."""
+
+    contract_id = PUBLIC_ID
+
+    @classmethod
+    def get_raw_balance(
+        cls,
+        ledger_api: EthereumApi,
+        contract_address: str,
+        address_to_check: str,
+    ) -> JSONLike:
+        """Get the balance of a given address."""
+        contract_instance = cls.get_instance(ledger_api, contract_address)
+        balance_of = getattr(contract_instance.functions, "balanceOf")  # noqa
+        token_balance = balance_of(address_to_check).call()
+        return dict(balance=token_balance)
+            

--- a/packages/valory/contracts/token_reader/contract.yaml
+++ b/packages/valory/contracts/token_reader/contract.yaml
@@ -1,0 +1,31 @@
+name: token_reader
+author: valory
+version: 0.1.0
+type: contract
+description: A simple contract to read token balances
+license: Apache-2.0
+aea_version: '>=1.0.0, <2.0.0'
+fingerprint:
+  README.md: bafybeifmfma6rglvpa22odtozyosnp5mwljum64utxip2wgmezuhnjjjyi
+  __init__.py: bafybeif5vpc3dfrlxlch7brbhmdwksabyzddpfqgm56vdbbkek3t3br6ke
+  build/token_reader.json: bafybeiemn5b5nszuss7xj6lmvmjuendltp6wz7ubihdvd7c6wqw4bohbpa
+  contract.py: bafybeigvhzl74hizdepy3dlscc5oaazj4anxxqzzafky7cmz3dy4d5skgq
+fingerprint_ignore_patterns: []
+contracts: []
+class_name: TokenReaderContract
+contract_interface_paths:
+  ethereum: build/token_reader.json
+dependencies:
+  ecdsa:
+    version: '>=0.15'
+  eth_typing: {}
+  hexbytes: {}
+  open-aea-ledger-ethereum:
+    version: ==1.57.0
+  open-aea-test-autonomy:
+    version: ==0.16.1
+  packaging: {}
+  requests:
+    version: ==2.28.1
+  web3:
+    version: <7,>=6.0.0

--- a/packages/valory/services/learning_service/service.yaml
+++ b/packages/valory/services/learning_service/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeid42pdrf6qrohedylj4ijrss236ai6geqgf3he44huowiuf7pl464
 fingerprint_ignore_patterns: []
-agent: valory/learning_agent:0.1.0:bafybeic3rit67tvl5zzvwbxjmthkr5uykx46y4zxphjarfnya4f6vof7sy
+agent: valory/learning_agent:0.1.0:bafybeidjdpdkwrr2wpgoqqmp6ycn37ji2wobquvhdnc2uexksr2glknloy
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/skills/learning_abci/payloads.py
+++ b/packages/valory/skills/learning_abci/payloads.py
@@ -20,7 +20,7 @@
 """This module contains the transaction payloads of the LearningAbciApp."""
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Dict, Optional, Tuple
 
 from packages.valory.skills.abstract_round_abci.base import BaseTxPayload
 
@@ -40,7 +40,6 @@ class DecisionMakingPayload(BaseTxPayload):
     """Represent a transaction payload for the DecisionMakingRound."""
 
     event: str
-
 
 @dataclass(frozen=True)
 class TxPreparationPayload(BaseTxPayload):
@@ -62,3 +61,8 @@ class NativeTransferPayload(BaseTxPayload):
 
     tx_submitter: Optional[str]
     tx_hash: Optional[str]
+
+@dataclass(frozen=True)
+class TokenBalanceCheckPayload(BaseTxPayload):
+    """Payload for token balance check."""
+    token_balance: Optional[float]

--- a/packages/valory/skills/learning_abci/skill.yaml
+++ b/packages/valory/skills/learning_abci/skill.yaml
@@ -7,19 +7,20 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeiho3lkochqpmes4f235chq26oggmwnol3vjuvhosleoubbjirbwaq
-  behaviours.py: bafybeid2styrysmcvpbeht66az7gnsdfpa7wm436fq52bdduguk7pwmzxm
+  behaviours.py: bafybeiczs6csrwvtt3wj7kgy67yh4w32mlxfaf3vqzh3fkcp7zchsrkjze
   dialogues.py: bafybeifqjbumctlffx2xvpga2kcenezhe47qhksvgmaylyp5ypwqgfar5u
   fsm_specification.yaml: bafybeigbbydxuqephdpatb3fp3sxnvr77bfvvo5hwjimxfpgyl32wupe64
   handlers.py: bafybeigjadr4thz6hfpfx5abezbwnqhbxmachf4efasrn4z2vqhsqgnyvi
   models.py: bafybeibpz5c7ojnokg54pcjfexmgkpy2pnvrubd6vh6pgazzojfhwxxm2u
-  payloads.py: bafybeiegiapnm5zkchgb5mloggk446q375pogjrj6diph4oxzpxw3uboqi
-  rounds.py: bafybeihm47ykgf5si6kgzcyryvme5ph5jm27g7nydl2s3lavtaoyhumcf4
+  payloads.py: bafybeidg4h7n63akyvvkstxfhq7syageemcugucdjil3esfhr2ppreimg4
+  rounds.py: bafybeib66dmjl4qju2q4kb2efliqntnlt37ocgs23fpgg5vmmq6ydokotu
 fingerprint_ignore_patterns: []
 connections: []
 contracts:
 - valory/gnosis_safe:0.1.0:bafybeib375xmvcplw7ageic2np3hq4yqeijrvd5kl7rrdnyvswats6ngmm
 - valory/erc20:0.1.0:bafybeibyhuxozkkvsymqz45vxixr3w3bs4vsvxg2nsx5jlyi3f3hhn7ezi
 - valory/multisend:0.1.0:bafybeig5byt5urg2d2bsecufxe5ql7f4mezg3mekfleeh32nmuusx66p4y
+- valory/token_reader:0.1.0:bafybeifmylu4yddfy2zyrb34cw5fcxrkj7x73zbvlxhrdc7cqxnt5jypti
 protocols:
 - valory/contract_api:1.0.0:bafybeidgu7o5llh26xp3u3ebq3yluull5lupiyeu6iooi2xyymdrgnzq5i
 - valory/ledger_api:1.0.0:bafybeihdk6psr4guxmbcrc26jr2cbgzpd5aljkqvpwo64bvaz7tdti2oni

--- a/packages/valory/skills/learning_chained_abci/skill.yaml
+++ b/packages/valory/skills/learning_chained_abci/skill.yaml
@@ -22,7 +22,7 @@ skills:
 - valory/registration_abci:0.1.0:bafybeiffipsowrqrkhjoexem7ern5ob4fabgif7wa6gtlszcoaop2e3oey
 - valory/reset_pause_abci:0.1.0:bafybeif4lgvbzsmzljesxbphycdv52ka7qnihyjrjpfaseclxadcmm6yiq
 - valory/termination_abci:0.1.0:bafybeiekkpo5qef5zaeagm3si6v45qxcojvtjqe4a5ceccvk4q7k3xi3bi
-- valory/learning_abci:0.1.0:bafybeiec7b3trh5q2xyvanqm5kttqbysdnp7rwac4nx4yvifimz7rw4qzy
+- valory/learning_abci:0.1.0:bafybeia3hfwbnfiaovv7ck4hodssd5xvsynrg5gz7h6o2kwlggbh6ct6bm
 - valory/transaction_settlement_abci:0.1.0:bafybeielv6eivt2z6nforq43xewl2vmpfwpdu2s2vfogobziljnwsclmlm
 behaviours:
   main:


### PR DESCRIPTION
Title: feat: Add Token Balance Check Round and Behaviour

**Problem:** 
Need to check token balances using custom package

**Solution:**
- Added `TokenBalanceCheckPayload` to transmit balance data
- Created `TokenBalanceCheckRound` with consensus mechanism 
- Implemented `TokenBalanceCheckBehaviour` for contract interaction
- State machine flow: SpaceXData -> TokenBalanceCheck -> DecisionMaking

**Changes:**
```python
# New state transitions
SpaceXDataRound: {
    Event.NO_MAJORITY: SpaceXDataRound,
    Event.ROUND_TIMEOUT: SpaceXDataRound,
    Event.DONE: TokenBalanceCheckRound,
},
TokenBalanceCheckRound: {
    Event.NO_MAJORITY: TokenBalanceCheckRound, 
    Event.ROUND_TIMEOUT: TokenBalanceCheckRound,
    Event.DONE: DecisionMakingRound,
}

token_reader contract package
```

**Testing:**
✓ Safe address token balance checks
✓ Consensus verification
✓ State transitions
✓ Logging

Future scope:
- Multi-token support
- Balance thresholds
- Historical tracking